### PR TITLE
Add week planner frontend prototype

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,532 @@
+const state = {
+  currentUser: null,
+  weekSelection: null,
+  daySelection: null,
+  users: [],
+  tasks: [],
+};
+
+const elements = {
+  sidebar: document.getElementById('sidebar'),
+  toggleSidebar: document.getElementById('toggleSidebar'),
+  navLinks: document.querySelectorAll('.nav-link'),
+  sections: document.querySelectorAll('.section'),
+  pageTitle: document.getElementById('pageTitle'),
+  pageSubtitle: document.getElementById('pageSubtitle'),
+  weeksGrid: document.getElementById('weeksGrid'),
+  weekView: document.getElementById('weekView'),
+  dayView: document.getElementById('dayView'),
+  weekTitle: document.getElementById('weekTitle'),
+  weekDays: document.getElementById('weekDays'),
+  dayTitle: document.getElementById('dayTitle'),
+  dayTasks: document.getElementById('dayTasks'),
+  backToGrid: document.getElementById('backToGrid'),
+  backToWeek: document.getElementById('backToWeek'),
+  profileForm: document.getElementById('profileForm'),
+  settingsForm: document.getElementById('settingsForm'),
+  taskFilter: document.getElementById('taskFilter'),
+  tasksOverview: document.getElementById('tasksOverview'),
+  adminPanel: document.getElementById('adminPanel'),
+  authDialog: document.getElementById('authDialog'),
+  openAuth: document.getElementById('openAuth'),
+  loginButton: document.getElementById('loginButton'),
+  registerButton: document.getElementById('registerButton'),
+  resetButton: document.getElementById('resetButton'),
+  authEmail: document.getElementById('authEmail'),
+  authPassword: document.getElementById('authPassword'),
+  authHint: document.getElementById('authHint'),
+  userChip: document.getElementById('userChip'),
+  logoutButton: document.getElementById('logoutButton'),
+  yearRange: document.getElementById('yearRange'),
+  startYear: document.getElementById('startYear'),
+};
+
+const storageKeys = {
+  users: 'weekboard.users',
+  tasks: 'weekboard.tasks',
+  currentUser: 'weekboard.currentUser',
+  settings: 'weekboard.settings',
+};
+
+const weekDays = ['Понедельник', 'Вторник', 'Среда', 'Четверг', 'Пятница', 'Суббота', 'Воскресенье'];
+
+const defaultTasks = [
+  {
+    id: 'task-1',
+    userId: 'admin',
+    title: 'Запуск платформы',
+    description: 'Проверить сетку недель и доступы.',
+    week: 12,
+    year: 2025,
+    day: 2,
+    deadline: '2025-03-18 18:00',
+    status: 'active',
+  },
+  {
+    id: 'task-2',
+    userId: 'user-1',
+    title: 'Контроль дедлайна',
+    description: 'Отправить отчёт куратору.',
+    week: 12,
+    year: 2025,
+    day: 4,
+    deadline: '2025-03-20 12:00',
+    status: 'overdue',
+  },
+  {
+    id: 'task-3',
+    userId: 'user-1',
+    title: 'Закрыть спринт',
+    description: 'Подготовить заметки по задачам.',
+    week: 13,
+    year: 2025,
+    day: 1,
+    deadline: '2025-03-25 17:00',
+    status: 'done',
+  },
+];
+
+const defaultUsers = [
+  {
+    id: 'admin',
+    email: 'admin@weekboard.local',
+    password: 'admin',
+    fullName: 'Администратор',
+    birthYear: 1990,
+    avatar: '',
+    role: 'admin',
+    access: ['user-1'],
+  },
+  {
+    id: 'user-1',
+    email: 'user@weekboard.local',
+    password: 'user',
+    fullName: 'Пользователь',
+    birthYear: 1998,
+    avatar: '',
+    role: 'user',
+    access: [],
+  },
+];
+
+function saveState() {
+  localStorage.setItem(storageKeys.users, JSON.stringify(state.users));
+  localStorage.setItem(storageKeys.tasks, JSON.stringify(state.tasks));
+  localStorage.setItem(storageKeys.currentUser, state.currentUser?.id ?? '');
+}
+
+function loadState() {
+  const storedUsers = JSON.parse(localStorage.getItem(storageKeys.users) || 'null');
+  const storedTasks = JSON.parse(localStorage.getItem(storageKeys.tasks) || 'null');
+  state.users = storedUsers || defaultUsers;
+  state.tasks = storedTasks || defaultTasks;
+  const currentUserId = localStorage.getItem(storageKeys.currentUser);
+  state.currentUser = state.users.find((user) => user.id === currentUserId) || null;
+}
+
+function formatWeekLabel(year, week) {
+  return `Неделя ${week} · ${year}`;
+}
+
+function setActiveSection(sectionId) {
+  elements.sections.forEach((section) => {
+    section.classList.toggle('section--active', section.id === `section-${sectionId}`);
+  });
+  elements.navLinks.forEach((link) => {
+    link.classList.toggle('active', link.dataset.section === sectionId);
+  });
+  if (sectionId === 'dashboard') {
+    elements.pageTitle.textContent = 'Календарь недель';
+    elements.pageSubtitle.textContent = 'Просмотр занятости по неделям и годам.';
+  }
+  if (sectionId === 'profile') {
+    elements.pageTitle.textContent = 'Профиль';
+    elements.pageSubtitle.textContent = 'Данные учетной записи и аватар.';
+  }
+  if (sectionId === 'settings') {
+    elements.pageTitle.textContent = 'Настройки';
+    elements.pageSubtitle.textContent = 'Время, формат и фон.';
+  }
+  if (sectionId === 'tasks') {
+    elements.pageTitle.textContent = 'Задачи';
+    elements.pageSubtitle.textContent = 'Списки по статусам и доступам.';
+  }
+}
+
+function updateUserChip() {
+  if (state.currentUser) {
+    elements.userChip.textContent = `${state.currentUser.fullName || state.currentUser.email}`;
+  } else {
+    elements.userChip.textContent = 'Гость';
+  }
+}
+
+function getVisibleUsers() {
+  if (!state.currentUser) {
+    return [];
+  }
+  if (state.currentUser.role === 'admin') {
+    return state.users;
+  }
+  return state.users.filter((user) => user.id === state.currentUser.id);
+}
+
+function canViewTasks(targetUserId) {
+  if (!state.currentUser) {
+    return false;
+  }
+  if (state.currentUser.role === 'admin') {
+    return true;
+  }
+  if (state.currentUser.id === targetUserId) {
+    return true;
+  }
+  return state.currentUser.access.includes(targetUserId);
+}
+
+function renderWeekGrid() {
+  elements.weeksGrid.innerHTML = '';
+  const startYear = Number(elements.startYear.value);
+  const range = Number(elements.yearRange.value);
+  const endYear = startYear + range - 1;
+  const visibleTasks = state.tasks.filter((task) => canViewTasks(task.userId));
+
+  for (let year = startYear; year <= endYear; year += 1) {
+    for (let week = 1; week <= 53; week += 1) {
+      const cell = document.createElement('div');
+      cell.className = 'week-cell';
+      cell.dataset.year = year;
+      cell.dataset.week = week;
+      const tasksForCell = visibleTasks.filter((task) => task.year === year && task.week === week);
+      if (tasksForCell.some((task) => task.status === 'overdue')) {
+        cell.dataset.status = 'overdue';
+      } else if (tasksForCell.length) {
+        cell.dataset.status = 'busy';
+      }
+      cell.title = formatWeekLabel(year, week);
+      cell.addEventListener('click', () => openWeekView(year, week));
+      elements.weeksGrid.appendChild(cell);
+    }
+  }
+}
+
+function openWeekView(year, week) {
+  state.weekSelection = { year, week };
+  state.daySelection = null;
+  elements.weekTitle.textContent = formatWeekLabel(year, week);
+  elements.weekView.scrollIntoView({ behavior: 'smooth' });
+  renderWeekDays();
+}
+
+function renderWeekDays() {
+  elements.weekDays.innerHTML = '';
+  if (!state.weekSelection) {
+    return;
+  }
+  const { year, week } = state.weekSelection;
+  const tasksForWeek = state.tasks.filter(
+    (task) => task.year === year && task.week === week && canViewTasks(task.userId)
+  );
+
+  weekDays.forEach((day, index) => {
+    const dayTasks = tasksForWeek.filter((task) => task.day === index + 1);
+    const dayCard = document.createElement('div');
+    dayCard.className = 'week-day';
+    dayCard.innerHTML = `
+      <h4>${day}</h4>
+      <p>${dayTasks.length ? `${dayTasks.length} задач(и)` : 'Нет задач'}</p>
+      <p>Ближайший дедлайн: ${dayTasks[0]?.deadline || '—'}</p>
+    `;
+    dayCard.addEventListener('click', () => openDayView(day, index + 1));
+    elements.weekDays.appendChild(dayCard);
+  });
+}
+
+function openDayView(dayLabel, dayNumber) {
+  state.daySelection = { label: dayLabel, dayNumber };
+  elements.dayTitle.textContent = `${dayLabel} · ${formatWeekLabel(state.weekSelection.year, state.weekSelection.week)}`;
+  renderDayTasks();
+  elements.dayView.scrollIntoView({ behavior: 'smooth' });
+}
+
+function renderDayTasks() {
+  elements.dayTasks.innerHTML = '';
+  if (!state.weekSelection || !state.daySelection) {
+    return;
+  }
+  const { year, week } = state.weekSelection;
+  const { dayNumber } = state.daySelection;
+  const dayTasks = state.tasks.filter(
+    (task) =>
+      task.year === year && task.week === week && task.day === dayNumber && canViewTasks(task.userId)
+  );
+  if (!dayTasks.length) {
+    elements.dayTasks.innerHTML = '<p class="muted">Задачи не найдены.</p>';
+    return;
+  }
+  dayTasks.forEach((task) => {
+    const card = document.createElement('div');
+    card.className = 'task-card';
+    card.dataset.status = task.status;
+    card.innerHTML = `
+      <strong>${task.title}</strong>
+      <span>${task.description}</span>
+      <span>Дедлайн: ${task.deadline}</span>
+      <span>Ответственный: ${getUserName(task.userId)}</span>
+    `;
+    elements.dayTasks.appendChild(card);
+  });
+}
+
+function renderTasksOverview() {
+  elements.tasksOverview.innerHTML = '';
+  const filter = elements.taskFilter.value;
+  const visibleTasks = state.tasks.filter((task) => canViewTasks(task.userId));
+  const filteredTasks = visibleTasks.filter((task) => task.status === filter);
+  if (!filteredTasks.length) {
+    elements.tasksOverview.innerHTML = '<p class="muted">Нет задач для выбранного статуса.</p>';
+    return;
+  }
+  filteredTasks.forEach((task) => {
+    const card = document.createElement('div');
+    card.className = 'task-card';
+    card.dataset.status = task.status;
+    card.innerHTML = `
+      <strong>${task.title}</strong>
+      <span>${task.description}</span>
+      <span>${formatWeekLabel(task.year, task.week)} · ${weekDays[task.day - 1]}</span>
+      <span>Дедлайн: ${task.deadline}</span>
+    `;
+    elements.tasksOverview.appendChild(card);
+  });
+}
+
+function renderAdminPanel() {
+  elements.adminPanel.innerHTML = '';
+  if (!state.currentUser || state.currentUser.role !== 'admin') {
+    elements.adminPanel.innerHTML = '<p class="muted">Доступно только администратору.</p>';
+    return;
+  }
+  state.users
+    .filter((user) => user.role !== 'admin')
+    .forEach((user) => {
+      const row = document.createElement('div');
+      row.className = 'admin-row';
+      const hasAccess = state.currentUser.access.includes(user.id);
+      row.innerHTML = `
+        <div>
+          <strong>${user.fullName || user.email}</strong>
+          <small>${user.email}</small>
+        </div>
+        <button class="ghost-button">${hasAccess ? 'Отозвать доступ' : 'Дать доступ'}</button>
+      `;
+      row.querySelector('button').addEventListener('click', () => {
+        toggleAdminAccess(user.id);
+      });
+      elements.adminPanel.appendChild(row);
+    });
+}
+
+function toggleAdminAccess(userId) {
+  const access = state.currentUser.access;
+  if (access.includes(userId)) {
+    state.currentUser.access = access.filter((id) => id !== userId);
+  } else {
+    state.currentUser.access = [...access, userId];
+  }
+  saveState();
+  renderAdminPanel();
+  renderWeekGrid();
+  renderTasksOverview();
+}
+
+function getUserName(userId) {
+  const user = state.users.find((item) => item.id === userId);
+  return user?.fullName || user?.email || 'Неизвестно';
+}
+
+function applySettings(settings) {
+  if (settings?.background) {
+    document.documentElement.style.setProperty('--bg', settings.background);
+  }
+}
+
+function saveProfile(event) {
+  event.preventDefault();
+  if (!state.currentUser) {
+    elements.authHint.textContent = 'Войдите, чтобы сохранить профиль.';
+    return;
+  }
+  const formData = new FormData(elements.profileForm);
+  Object.assign(state.currentUser, {
+    fullName: formData.get('fullName'),
+    birthYear: Number(formData.get('birthYear')) || '',
+    avatar: formData.get('avatar'),
+    email: formData.get('email'),
+  });
+  saveState();
+  updateUserChip();
+}
+
+function saveSettings(event) {
+  event.preventDefault();
+  const formData = new FormData(elements.settingsForm);
+  const settings = {
+    time: formData.get('time'),
+    date: formData.get('date'),
+    dateFormat: formData.get('dateFormat'),
+    background: formData.get('background'),
+  };
+  localStorage.setItem(storageKeys.settings, JSON.stringify(settings));
+  applySettings(settings);
+}
+
+function handleLogin(event, mode) {
+  event.preventDefault();
+  const email = elements.authEmail.value.trim();
+  const password = elements.authPassword.value.trim();
+  if (!email || !password) {
+    elements.authHint.textContent = 'Введите почту и пароль.';
+    return;
+  }
+  if (mode === 'login') {
+    const user = state.users.find((item) => item.email === email && item.password === password);
+    if (!user) {
+      elements.authHint.textContent = 'Неверные данные для входа.';
+      return;
+    }
+    state.currentUser = user;
+    saveState();
+    updateUserChip();
+    elements.authDialog.close();
+    renderAfterAuth();
+    return;
+  }
+  if (mode === 'register') {
+    if (state.users.some((item) => item.email === email)) {
+      elements.authHint.textContent = 'Пользователь уже существует.';
+      return;
+    }
+    const newUser = {
+      id: `user-${Date.now()}`,
+      email,
+      password,
+      fullName: email.split('@')[0],
+      birthYear: '',
+      avatar: '',
+      role: 'user',
+      access: [],
+    };
+    state.users.push(newUser);
+    state.currentUser = newUser;
+    saveState();
+    updateUserChip();
+    elements.authDialog.close();
+    renderAfterAuth();
+    return;
+  }
+  if (mode === 'reset') {
+    const existing = state.users.find((item) => item.email === email);
+    if (!existing) {
+      elements.authHint.textContent = 'Нет пользователя с такой почтой.';
+      return;
+    }
+    elements.authHint.textContent = 'Ссылка для сброса отправлена на почту (демо).';
+  }
+}
+
+function renderAfterAuth() {
+  renderWeekGrid();
+  renderWeekDays();
+  renderDayTasks();
+  renderTasksOverview();
+  renderAdminPanel();
+}
+
+function populateYears() {
+  const currentYear = new Date().getFullYear();
+  elements.startYear.innerHTML = '';
+  for (let year = currentYear - 10; year <= currentYear + 10; year += 1) {
+    const option = document.createElement('option');
+    option.value = year;
+    option.textContent = year;
+    if (year === currentYear - 5) {
+      option.selected = true;
+    }
+    elements.startYear.appendChild(option);
+  }
+}
+
+function initListeners() {
+  elements.toggleSidebar.addEventListener('click', () => {
+    elements.sidebar.classList.toggle('collapsed');
+  });
+
+  elements.navLinks.forEach((link) => {
+    link.addEventListener('click', () => {
+      setActiveSection(link.dataset.section);
+    });
+  });
+
+  elements.backToGrid.addEventListener('click', () => {
+    elements.weekView.scrollIntoView({ behavior: 'smooth' });
+  });
+
+  elements.backToWeek.addEventListener('click', () => {
+    elements.weekView.scrollIntoView({ behavior: 'smooth' });
+  });
+
+  elements.profileForm.addEventListener('submit', saveProfile);
+  elements.settingsForm.addEventListener('submit', saveSettings);
+
+  elements.taskFilter.addEventListener('change', renderTasksOverview);
+
+  elements.openAuth.addEventListener('click', () => {
+    elements.authHint.textContent = '';
+    elements.authDialog.showModal();
+  });
+
+  elements.loginButton.addEventListener('click', (event) => handleLogin(event, 'login'));
+  elements.registerButton.addEventListener('click', (event) => handleLogin(event, 'register'));
+  elements.resetButton.addEventListener('click', (event) => handleLogin(event, 'reset'));
+
+  elements.logoutButton.addEventListener('click', () => {
+    state.currentUser = null;
+    saveState();
+    updateUserChip();
+    renderAfterAuth();
+  });
+
+  elements.yearRange.addEventListener('change', renderWeekGrid);
+  elements.startYear.addEventListener('change', renderWeekGrid);
+}
+
+function hydrateForms() {
+  if (state.currentUser) {
+    elements.profileForm.fullName.value = state.currentUser.fullName || '';
+    elements.profileForm.birthYear.value = state.currentUser.birthYear || '';
+    elements.profileForm.avatar.value = state.currentUser.avatar || '';
+    elements.profileForm.email.value = state.currentUser.email || '';
+  }
+  const settings = JSON.parse(localStorage.getItem(storageKeys.settings) || 'null');
+  if (settings) {
+    elements.settingsForm.time.value = settings.time || '';
+    elements.settingsForm.date.value = settings.date || '';
+    elements.settingsForm.dateFormat.value = settings.dateFormat || 'dd.mm.yyyy';
+    elements.settingsForm.background.value = settings.background || '#f6f7fb';
+  }
+  applySettings(settings);
+}
+
+function init() {
+  loadState();
+  populateYears();
+  updateUserChip();
+  initListeners();
+  hydrateForms();
+  renderWeekGrid();
+  renderTasksOverview();
+  renderAdminPanel();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Планировщик недель</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar__header">
+        <h1>WeekBoard</h1>
+        <button class="icon-button" id="toggleSidebar" aria-label="Скрыть меню">⟨⟩</button>
+      </div>
+      <nav class="sidebar__nav">
+        <button class="nav-link active" data-section="dashboard">Главная</button>
+        <button class="nav-link" data-section="profile">Профиль</button>
+        <button class="nav-link" data-section="settings">Настройки</button>
+        <button class="nav-link" data-section="tasks">Задачи</button>
+      </nav>
+      <div class="sidebar__footer">
+        <div class="user-chip" id="userChip">Гость</div>
+        <button class="ghost-button" id="logoutButton">Выйти</button>
+      </div>
+    </aside>
+
+    <main class="content">
+      <header class="content__header">
+        <div>
+          <h2 id="pageTitle">Календарь недель</h2>
+          <p id="pageSubtitle">Просмотр занятости по неделям и годам.</p>
+        </div>
+        <div class="header-actions">
+          <button class="ghost-button" id="openAuth">Войти / Регистрация</button>
+        </div>
+      </header>
+
+      <section class="section section--active" id="section-dashboard">
+        <div class="card">
+          <div class="card__header">
+            <div>
+              <h3>Таблица недель</h3>
+              <p>Кликните на неделю, чтобы открыть дневник.</p>
+            </div>
+            <div class="card__actions">
+              <label class="select-label">
+                Годы
+                <select id="yearRange">
+                  <option value="10">10 лет</option>
+                  <option value="20" selected>20 лет</option>
+                  <option value="50">50 лет</option>
+                </select>
+              </label>
+              <label class="select-label">
+                Начальный год
+                <select id="startYear"></select>
+              </label>
+            </div>
+          </div>
+          <div class="weeks-grid" id="weeksGrid"></div>
+        </div>
+
+        <div class="card" id="weekView">
+          <div class="card__header">
+            <div>
+              <h3 id="weekTitle">Неделя</h3>
+              <p>Недельный обзор с задачами и временем.</p>
+            </div>
+            <div class="card__actions">
+              <button class="ghost-button" id="backToGrid">← К таблице</button>
+            </div>
+          </div>
+          <div class="week-days" id="weekDays"></div>
+        </div>
+
+        <div class="card" id="dayView">
+          <div class="card__header">
+            <div>
+              <h3 id="dayTitle">День</h3>
+              <p>Подробности задач, дедлайны и описание.</p>
+            </div>
+            <div class="card__actions">
+              <button class="ghost-button" id="backToWeek">← К неделе</button>
+            </div>
+          </div>
+          <div class="task-list" id="dayTasks"></div>
+        </div>
+      </section>
+
+      <section class="section" id="section-profile">
+        <div class="card">
+          <div class="card__header">
+            <div>
+              <h3>Профиль</h3>
+              <p>Редактируйте личные данные.</p>
+            </div>
+          </div>
+          <form class="form" id="profileForm">
+            <label>
+              ФИО
+              <input type="text" name="fullName" placeholder="Иванов Иван" />
+            </label>
+            <label>
+              Год рождения
+              <input type="number" name="birthYear" min="1900" max="2025" />
+            </label>
+            <label>
+              Фото (URL)
+              <input type="url" name="avatar" placeholder="https://" />
+            </label>
+            <label>
+              Почта
+              <input type="email" name="email" placeholder="email@example.com" />
+            </label>
+            <button type="submit" class="primary-button">Сохранить</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="section" id="section-settings">
+        <div class="card">
+          <div class="card__header">
+            <div>
+              <h3>Настройки</h3>
+              <p>Управляйте отображением и временем.</p>
+            </div>
+          </div>
+          <form class="form" id="settingsForm">
+            <label>
+              Время
+              <input type="time" name="time" />
+            </label>
+            <label>
+              Дата
+              <input type="date" name="date" />
+            </label>
+            <label>
+              Формат даты
+              <select name="dateFormat">
+                <option value="dd.mm.yyyy">ДД.ММ.ГГГГ</option>
+                <option value="yyyy-mm-dd">ГГГГ-ММ-ДД</option>
+              </select>
+            </label>
+            <label>
+              Цвет фона
+              <input type="color" name="background" value="#f6f7fb" />
+            </label>
+            <button type="submit" class="primary-button">Применить</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="section" id="section-tasks">
+        <div class="card">
+          <div class="card__header">
+            <div>
+              <h3>Задачи</h3>
+              <p>Просмотр актуальных, просроченных и закрытых задач.</p>
+            </div>
+            <div class="card__actions">
+              <select id="taskFilter">
+                <option value="active">Актуальные</option>
+                <option value="overdue">Просроченные</option>
+                <option value="done">Закрытые</option>
+              </select>
+            </div>
+          </div>
+          <div class="task-list" id="tasksOverview"></div>
+        </div>
+        <div class="card">
+          <div class="card__header">
+            <div>
+              <h3>Администрирование</h3>
+              <p>Администратор может выдавать доступ на просмотр задач.</p>
+            </div>
+          </div>
+          <div class="admin-panel" id="adminPanel"></div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <dialog id="authDialog">
+    <form method="dialog" class="auth">
+      <div class="auth__header">
+        <h3>Вход и регистрация</h3>
+        <button class="icon-button" value="cancel">✕</button>
+      </div>
+      <label>
+        Почта
+        <input type="email" id="authEmail" required />
+      </label>
+      <label>
+        Пароль
+        <input type="password" id="authPassword" required />
+      </label>
+      <div class="auth__actions">
+        <button class="primary-button" id="loginButton" value="default">Войти</button>
+        <button class="ghost-button" id="registerButton" value="default">Регистрация</button>
+        <button class="ghost-button" id="resetButton" value="default">Сбросить пароль</button>
+      </div>
+      <p class="auth__hint" id="authHint"></p>
+    </form>
+  </dialog>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,370 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7fb;
+  --card: #ffffff;
+  --text: #1b1d24;
+  --muted: #6a7280;
+  --accent: #3759d7;
+  --border: #d7dbe7;
+  --success: #1f9d6a;
+  --warning: #e67e22;
+  --danger: #d64545;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 260px;
+  background: #111827;
+  color: #f8fafc;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  transition: transform 0.3s ease;
+}
+
+.sidebar.collapsed {
+  transform: translateX(-100%);
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nav-link {
+  background: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  font-size: 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-link.active,
+.nav-link:hover {
+  background: #1f2937;
+  border-color: #334155;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.user-chip {
+  background: #1f2937;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 14px;
+}
+
+.content {
+  flex: 1;
+  padding: 32px 40px;
+}
+
+.content__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  gap: 20px;
+}
+
+.content__header h2 {
+  font-size: 28px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.08);
+  margin-bottom: 24px;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.card__header h3 {
+  font-size: 20px;
+}
+
+.card__header p {
+  color: var(--muted);
+  margin-top: 6px;
+}
+
+.card__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.select-label {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  color: var(--muted);
+  gap: 6px;
+}
+
+.weeks-grid {
+  overflow-x: auto;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 16px;
+  display: grid;
+  grid-template-columns: repeat(53, minmax(18px, 1fr));
+  gap: 4px;
+  background: #fdfdfd;
+}
+
+.week-cell {
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.week-cell:hover {
+  transform: scale(1.1);
+  border-color: var(--accent);
+}
+
+.week-cell[data-status="busy"] {
+  background: rgba(55, 89, 215, 0.25);
+  border-color: rgba(55, 89, 215, 0.5);
+}
+
+.week-cell[data-status="overdue"] {
+  background: rgba(214, 69, 69, 0.25);
+  border-color: rgba(214, 69, 69, 0.5);
+}
+
+.section {
+  display: none;
+}
+
+.section--active {
+  display: block;
+}
+
+.week-days {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.week-day {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.week-day:hover {
+  border-color: var(--accent);
+}
+
+.week-day h4 {
+  margin-bottom: 8px;
+}
+
+.week-day p {
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.task-list {
+  display: grid;
+  gap: 12px;
+}
+
+.task-card {
+  border: 1px solid var(--border);
+  border-left: 6px solid var(--accent);
+  border-radius: 12px;
+  padding: 14px;
+  display: grid;
+  gap: 6px;
+}
+
+.task-card[data-status="overdue"] {
+  border-left-color: var(--danger);
+}
+
+.task-card[data-status="done"] {
+  border-left-color: var(--success);
+  opacity: 0.7;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.form {
+  display: grid;
+  gap: 16px;
+  max-width: 420px;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 6px;
+}
+
+input,
+select,
+button,
+textarea {
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  font-size: 14px;
+}
+
+button {
+  cursor: pointer;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.icon-button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.admin-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  gap: 12px;
+}
+
+.admin-row small {
+  color: var(--muted);
+}
+
+dialog {
+  border: none;
+  border-radius: 16px;
+  padding: 0;
+  width: min(420px, 90vw);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+dialog::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.auth {
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.auth__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.auth__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.auth__hint {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+@media (max-width: 960px) {
+  .sidebar {
+    position: fixed;
+    z-index: 10;
+    height: 100vh;
+  }
+
+  .content {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 720px) {
+  .content__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .weeks-grid {
+    grid-template-columns: repeat(26, minmax(18px, 1fr));
+  }
+}


### PR DESCRIPTION
### Motivation

- Implement a frontend prototype for a week-based planner that shows weeks horizontally and years vertically with drill-down to week/day views and task details.
- Provide multi-user demo flows including registration/login/reset, per-user task visibility and an admin panel for granting view access.
- Offer client-side settings (time/date/format/background) and basic local persistence for a quick interactive demo.

### Description

- Added `index.html` containing a single-page layout with a collapsible sidebar, sections for Dashboard/Profile/Settings/Tasks, a week grid, week/day views and an auth dialog.
- Added `styles.css` with responsive styling for the sidebar, week grid, cards, forms, dialogs and visual task status markers (busy/overdue/done).
- Added `app.js` implementing client-side state, demo `defaultUsers`/`defaultTasks`, `localStorage` persistence, week grid generation, week/day drill-down, task rendering, auth (login/register/reset) and admin access toggles.
- Implemented year-range population, settings application (background), and UI listeners for navigation, profile/settings save and task filtering.

### Testing

- Served the site with `python -m http.server 8000 --directory /workspace/project` and exercised the UI by running a Playwright script that opened `http://127.0.0.1:8000/index.html` and saved a screenshot; the script completed successfully and produced `artifacts/weekboard.png`.
- No unit or integration tests were added for this prototype.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f2ce5b7083218e95a993d5dd528e)